### PR TITLE
Discovered updates to StateMachine source

### DIFF
--- a/Allocator.cpp
+++ b/Allocator.cpp
@@ -18,7 +18,7 @@ Allocator::Allocator(size_t size, UINT objects, CHAR* memory, const CHAR* name) 
     m_deallocations(0),
     m_name(name)
 {
-    // If using a fixed memory pool 
+    // If using a fixed memory pool
 	if (m_maxObjects)
 	{
 		// If caller provided an external memory pool
@@ -27,7 +27,7 @@ Allocator::Allocator(size_t size, UINT objects, CHAR* memory, const CHAR* name) 
 			m_pPool = memory;
 			m_allocatorMode = STATIC_POOL;
 		}
-		else 
+		else
 		{
 			m_pPool = (CHAR*)new CHAR[m_blockSize * m_maxObjects];
 			m_allocatorMode = HEAP_POOL;
@@ -42,7 +42,7 @@ Allocator::Allocator(size_t size, UINT objects, CHAR* memory, const CHAR* name) 
 //------------------------------------------------------------------------------
 Allocator::~Allocator()
 {
-	// If using pool then destroy it, otherwise traverse free-list and 
+	// If using pool then destroy it, otherwise traverse free-list and
 	// destroy each individual block
 	if (m_allocatorMode == HEAP_POOL)
 		delete [] m_pPool;
@@ -58,44 +58,37 @@ Allocator::~Allocator()
 //------------------------------------------------------------------------------
 void* Allocator::Allocate(size_t size)
 {
-    ASSERT_TRUE(size <= m_objectSize);
-	
-    // If can't obtain existing block then get a new one
-    void* pBlock = Pop();
-    if (!pBlock)
-    {
-        // If using a pool method then get block from pool,
-        // otherwise using dynamic so get block from heap
-        if (m_maxObjects)
-        {
-            // If we have not exceeded the pool maximum
-            if(m_poolIndex < m_maxObjects)
-            {
-                pBlock = (void*)(m_pPool + (m_poolIndex++ * m_blockSize));
-            }
-            else
-            {
-                // Get the pointer to the new handler
-                std::new_handler handler = std::set_new_handler(0);
-                std::set_new_handler(handler);
+  SM_ASSERT_TRUE(size <= m_objectSize);
 
-                // If a new handler is defined, call it
-                if (handler)
-                    (*handler)();
-                else
-                    ASSERT();
-            }
-        }
+  // If can't obtain existing block then get a new one
+  void* pBlock = Pop();
+  if (!pBlock) {
+    // If using a pool method then get block from pool,
+    // otherwise using dynamic so get block from heap
+    if (m_maxObjects) {
+      // If we have not exceeded the pool maximum
+      if (m_poolIndex < m_maxObjects) {
+        pBlock = (void*)(m_pPool + (m_poolIndex++ * m_blockSize));
+      } else {
+        // Get the pointer to the new handler
+        std::new_handler handler = std::set_new_handler(0);
+        std::set_new_handler(handler);
+
+        // If a new handler is defined, call it
+        if (handler)
+          (*handler)();
         else
-        {
-        	m_blockCnt++;
-            pBlock = (void*)new CHAR[m_blockSize];
-        }
+          ASSERT();
+      }
+    } else {
+      m_blockCnt++;
+      pBlock = (void*)new CHAR[m_blockSize];
+    }
     }
 
     m_blocksInUse++;
     m_allocations++;
-	
+
     return pBlock;
 }
 

--- a/Fault.h
+++ b/Fault.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-// Used for compile-time checking for array sizes. On Windows VC++, you get 
+// Used for compile-time checking for array sizes. On Windows VC++, you get
 // an "error C2118: negative subscript" error.
 #ifndef C_ASSERT
 #define C_ASSERT(expr)  {char uname[(expr)?1:-1];uname[0]=0;}
@@ -16,10 +16,12 @@ extern "C" {
 #define ASSERT() \
 	FaultHandler(__FILE__, (unsigned short) __LINE__)
 
-#define ASSERT_TRUE(condition) \
-	do {if (!(condition)) FaultHandler(__FILE__, (unsigned short) __LINE__);} while (0)
+#define SM_ASSERT_TRUE(condition)                                       \
+  do {                                                                  \
+    if (!(condition)) FaultHandler(__FILE__, (unsigned short)__LINE__); \
+  } while (0)
 
-	/// Handles all software assertions in the system.
+        /// Handles all software assertions in the system.
 	/// @param[in] file - the file name that the software assertion occurred on
 	/// @param[in] line - the line number that the software assertion occurred on
 	void FaultHandler(const char* file, unsigned short line);
@@ -28,4 +30,4 @@ extern "C" {
 }
 #endif
 
-#endif 
+#endif

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ switch (currentState) {
 <p>When an event is generated, it can optionally attach event data to be used by the state function during execution. Once the state has completed execution, the event data is considered used up and must be deleted. Therefore, any event data sent to a state machine must be created on the heap, via operator new, so that the state machine can delete it once used. In addition, for our particular implementation the event data must inherit from the <code>EventData </code>base class. This gives the state machine engine a common base class for which to delete all event data.</p>
 
 <pre lang="c++">
-class EventData 
+class EventData
 {
 public:
     virtual ~EventData() {}
@@ -167,7 +167,7 @@ public:
 <p>The state machine source code is contained within the StateMachine.cpp and StateMachine.h files (see attached <em>StateMachine.zip</em>). The code below shows the class declaration.</p>
 
 <pre lang="c++">
-class StateMachine 
+class StateMachine
 {
 public:
     enum { EVENT_IGNORED = 0xFE, CANNOT_HAPPEN };
@@ -176,11 +176,11 @@ public:
     virtual ~StateMachine() {}
 
     BYTE GetCurrentState() { return m_currentState; }
-    
+
 protected:
     void ExternalEvent(BYTE newState, const EventData* pData = NULL);
     void InternalEvent(BYTE newState, const EventData* pData = NULL);
-    
+
 private:
     const BYTE MAX_STATES;
     BYTE m_currentState;
@@ -190,10 +190,10 @@ private:
 
     virtual const StateMapRow* GetStateMap() = 0;
     virtual const StateMapRowEx* GetStateMapEx() = 0;
-    
+
     void SetCurrentState(BYTE newState) { m_currentState = newState; }
 
-    void StateEngine(void);     
+    void StateEngine(void);
     void StateEngine(const StateMapRow* const pStateMap);
     void StateEngine(const StateMapRowEx* const pStateMapEx);
 };</pre>
@@ -234,7 +234,7 @@ public:
     void Halt();
 
 private:
-    INT m_currentSpeed; 
+    INT m_currentSpeed;
 
     // State enumeration order must match the order of state method entries
     // in the state map.
@@ -265,13 +265,13 @@ private:
 private:
     virtual const StateMapRowEx* GetStateMapEx() { return NULL; }
     virtual const StateMapRow* GetStateMap() {
-        static const StateMapRow STATE_MAP[] = { 
+        static const StateMapRow STATE_MAP[] = {
             &amp;Idle,
             &amp;Stop,
             &amp;Start,
             &amp;ChangeSpeed,
-        }; 
-        C_ASSERT((sizeof(STATE_MAP)/sizeof(StateMapRow)) == ST_MAX_STATES); 
+        };
+        C_ASSERT((sizeof(STATE_MAP)/sizeof(StateMapRow)) == ST_MAX_STATES);
         return &amp;STATE_MAP[0]; }
 };</pre>
 
@@ -295,7 +295,7 @@ public:
     void Halt();
 
 private:
-    INT m_currentSpeed; 
+    INT m_currentSpeed;
 
     // State enumeration order must match the order of state method entries
     // in the state map.
@@ -321,7 +321,7 @@ private:
         STATE_MAP_ENTRY(&amp;Stop)
         STATE_MAP_ENTRY(&amp;Start)
         STATE_MAP_ENTRY(&amp;ChangeSpeed)
-    END_STATE_MAP    
+    END_STATE_MAP
 };</pre>
 
 <p><code>Motor </code>implements our hypothetical motor-control state machine, where clients can start the motor, at a specific speed, and stop the motor. The<code> SetSpeed()</code> and <code>Halt() </code>public functions are considered external events into the <code>Motor </code>state machine. <code>SetSpeed()</code> takes event data, which contains the motor speed. This data structure will be deleted upon completion of the state processing, so it is imperative that the structure inherit from <code>EventData </code>and be created using <code>operator new </code>before the function call is made.</p>
@@ -386,7 +386,7 @@ StateAction&lt;Motor, MotorData, &amp;Motor::ST_ChangeSpeed&gt; ChangeSpeed;</pr
 STATE_DEFINE(Motor, Stop, NoEventData)
 {
     cout &lt;&lt; &quot;Motor::ST_Stop&quot; &lt;&lt; endl;
-    m_currentSpeed = 0; 
+    m_currentSpeed = 0;
 
     // perform the stop motor processing here
     // transition to Idle via an internal event
@@ -399,7 +399,7 @@ STATE_DEFINE(Motor, Stop, NoEventData)
 void Motor::ST_Stop(const NoEventData* data)
 {
     cout &lt;&lt; &quot;Motor::ST_Stop&quot; &lt;&lt; endl;
-    m_currentSpeed = 0; 
+    m_currentSpeed = 0;
 
     // perform the stop motor processing here
     // transition to Idle via an internal event
@@ -445,13 +445,13 @@ END_STATE_MAP    </pre>
 private:
     virtual const StateMapRowEx* GetStateMapEx() { return NULL; }
     virtual const StateMapRow* GetStateMap() {
-        static const StateMapRow STATE_MAP[] = { 
+        static const StateMapRow STATE_MAP[] = {
             &amp;Idle,
             &amp;Stop,
             &amp;Start,
             &amp;ChangeSpeed,
-        }; 
-        C_ASSERT((sizeof(STATE_MAP)/sizeof(StateMapRow)) == ST_MAX_STATES); 
+        };
+        C_ASSERT((sizeof(STATE_MAP)/sizeof(StateMapRow)) == ST_MAX_STATES);
         return &amp;STATE_MAP[0]; }</pre>
 
 <p>Notice the <code>C_ASSERT </code>macro. It provides compile time protection against a state map having the wrong number of entries. Visual Studio gives an error of &quot;error C2118: negative subscript&quot;. Your compiler may give a different error message.&nbsp;</p>
@@ -460,7 +460,7 @@ private:
 
 <pre lang="c++">
 BEGIN_STATE_MAP_EX
-STATE_MAP_ENTRY_EX or STATE_MAP_ENTRY_ALL_EX 
+STATE_MAP_ENTRY_EX or STATE_MAP_ENTRY_ALL_EX
 END_STATE_MAP_EX</pre>
 
 <p>The <code>STATE_MAP_ENTRY_ALL_EX </code>macro has four arguments for the state action, guard condition, entry action and exit action in that order. The state action is mandatory but the other actions are optional. If a state doesn&#39;t have an action, then use 0 for the argument. If a state doesn&#39;t have any guard/entry/exit options, the <code>STATE_MAP_ENTRY_EX </code>macro defaults all unused options to 0. The macro snippet below is for an advanced example presented later in the article.&nbsp;</p>
@@ -501,14 +501,14 @@ template &lt;class SM, class Data, void (SM::*Func)(const Data*)&gt;
 class StateAction : public StateBase
 {
 public:
-    virtual void InvokeStateAction(StateMachine* sm, const EventData* data) const 
+    virtual void InvokeStateAction(StateMachine* sm, const EventData* data) const
     {
         // Downcast the state machine and event data to the correct derived type
         SM* derivedSM = static_cast&lt;SM*&gt;(sm);
 
-        // Dynamic cast the data to the correct derived type        
+        // Dynamic cast the data to the correct derived type
         const Data* derivedData = dynamic_cast&lt;const Data*&gt;(data);
-        ASSERT_TRUE(derivedData != NULL);
+        SM_ASSERT_TRUE(derivedData != NULL);
 
         // Call the state function
         (derivedSM-&gt;*Func)(derivedData);
@@ -552,8 +552,8 @@ void Motor::Halt()
         ST_STOP,                          // ST_START
         ST_STOP,                          // ST_CHANGE_SPEED
     };
-    ExternalEvent(TRANSITIONS[GetCurrentState()], NULL); 
-    C_ASSERT((sizeof(TRANSITIONS)/sizeof(BYTE)) == ST_MAX_STATES);     
+    ExternalEvent(TRANSITIONS[GetCurrentState()], NULL);
+    C_ASSERT((sizeof(TRANSITIONS)/sizeof(BYTE)) == ST_MAX_STATES);
 }</pre>
 
 <p><code>BEGIN_TRANSITION_MAP</code> starts the map. Each <code>TRANSITION_MAP_ENTRY </code>that follows indicates what the state machine should do based upon the current state. The number of entries in each transition map table must match the number of state functions exactly. In our example, we have four state functions, so we need four entries. The location of each entry matches the order of state functions defined within the state map. Thus, the first entry within the <code>Halt()</code> function indicates an <code>EVENT_IGNORED</code> as shown below.&nbsp;</p>
@@ -603,17 +603,17 @@ state-&gt;InvokeStateAction(this, pDataTemp);</pre>
 <pre lang="c++">
 void StateMachine::StateEngine(const StateMapRow* const pStateMap)
 {
-    const EventData* pDataTemp = NULL;    
-    
+    const EventData* pDataTemp = NULL;
+
     // While events are being generated keep executing states
     while (m_eventGenerated)
     {
         // Error check that the new state is valid before proceeding
-        ASSERT_TRUE(m_newState &lt; MAX_STATES);
-    
+        SM_ASSERT_TRUE(m_newState &lt; MAX_STATES);
+
         // Get the pointer from the state map
         const StateBase* state = pStateMap[m_newState].State;
-            
+
            // Copy of event data pointer
         pDataTemp = m_pEventData;
 
@@ -627,7 +627,7 @@ void StateMachine::StateEngine(const StateMapRow* const pStateMap)
         SetCurrentState(m_newState);
 
         // Execute the state action passing in event data
-        ASSERT_TRUE(state != NULL);
+        SM_ASSERT_TRUE(state != NULL);
         state-&gt;InvokeStateAction(this, pDataTemp);
 
         // If event data was used, then delete it
@@ -770,7 +770,7 @@ STATE_DECLARE(SelfTest,     Failed,          NoEventData)</pre>
 enum States
 {
     // Continue state numbering using the last SelfTest::States enum value
-    ST_START_TEST = SelfTest::ST_MAX_STATES,    
+    ST_START_TEST = SelfTest::ST_MAX_STATES,
     ST_ACCELERATION,
     ST_WAIT_FOR_ACCELERATION,
     ST_DECELERATION,
@@ -839,9 +839,9 @@ void SelfTest::Cancel()
 <p>The <code>SUBCLASS_TRANSITION </code>example above is read &ldquo;If the Cancel event is generated when the state machine is <em>not</em> in <code>ST_IDLE</code>, <code>ST_COMPLETE</code>, or <code>ST_FAILED </code>then transition to the <code>ST_FAILED </code>state&rdquo;. The macro preceding the transition map is the catch-all if the current state is beyond what is known by the current state machine hierarchy level. The expanded <code>SUBCLASS_TRANSITION </code>macro for the above example is shown below.</p>
 
 <pre lang="c++">
-if (GetCurrentState() &gt;= ST_MAX_STATES &amp;&amp; 
-    GetCurrentState() &lt; GetMaxStates()) { 
-     ExternalEvent(ST_FAILED); 
+if (GetCurrentState() &gt;= ST_MAX_STATES &amp;&amp;
+    GetCurrentState() &lt; GetMaxStates()) {
+     ExternalEvent(ST_FAILED);
      return; }
 </pre>
 
@@ -882,7 +882,7 @@ STATE_DEFINE(CentrifugeTest,   Idle, NoEventData)
     cout &lt;&lt; &quot;CentrifugeTest::ST_Idle&quot; &lt;&lt; endl;
 
     // Call base class Idle state
-    SelfTest::ST_Idle(data);    
+    SelfTest::ST_Idle(data);
     StopPoll();
 }</pre>
 

--- a/StateMachine.cpp
+++ b/StateMachine.cpp
@@ -12,7 +12,7 @@ StateMachine::StateMachine(BYTE maxStates, BYTE initialState) :
 	m_pEventData(NULL)
 {
 	ASSERT_TRUE(MAX_STATES < EVENT_IGNORED);
-}  
+}
 
 //----------------------------------------------------------------------------
 // ExternalEvent
@@ -44,7 +44,7 @@ void StateMachine::ExternalEvent(BYTE newState, const EventData* pData)
 		// when all state machine events are processed.
 		StateEngine();
 
-		// TODO - release software lock here 
+		// TODO - release software lock here
 	}
 }
 
@@ -53,12 +53,17 @@ void StateMachine::ExternalEvent(BYTE newState, const EventData* pData)
 //----------------------------------------------------------------------------
 void StateMachine::InternalEvent(BYTE newState, const EventData* pData)
 {
-	if (pData == NULL)
+	// if (pData == NULL)
+	// 	pData = new NoEventData();
+#ifndef EXTERNAL_EVENT_NO_HEAP_DATA
+  if (pData == NULL) {
 		pData = new NoEventData();
+  }
+#endif  // EXTERNAL_EVENT_NO_HEAP_DATA
 
-	m_pEventData = pData;
-	m_eventGenerated = TRUE;
-	m_newState = newState;
+  m_pEventData = pData;
+  m_eventGenerated = TRUE;
+  m_newState = newState;
 }
 
 //----------------------------------------------------------------------------
@@ -87,7 +92,7 @@ void StateMachine::StateEngine(const StateMapRow* const pStateMap)
 #if EXTERNAL_EVENT_NO_HEAP_DATA
 	BOOL externalEvent = TRUE;
 #endif
-	const EventData* pDataTemp = NULL;	
+	const EventData* pDataTemp = NULL;
 
 	// While events are being generated keep executing states
 	while (m_eventGenerated)
@@ -183,7 +188,7 @@ void StateMachine::StateEngine(const StateMapRowEx* const pStateMapEx)
 				if (entry != NULL)
 					entry->InvokeEntryAction(this, pDataTemp);
 
-				// Ensure exit/entry actions didn't call InternalEvent by accident 
+				// Ensure exit/entry actions didn't call InternalEvent by accident
 				ASSERT_TRUE(m_eventGenerated == FALSE);
 			}
 

--- a/StateMachine.cpp
+++ b/StateMachine.cpp
@@ -123,8 +123,8 @@ void StateMachine::StateEngine(const StateMapRow* const pStateMap)
 #if EXTERNAL_EVENT_NO_HEAP_DATA
 		if (pDataTemp)
 		{
-			if (!externalEvent)
-				delete pDataTemp;
+			// if (!externalEvent)
+			// 	delete pDataTemp;
 			pDataTemp = NULL;
 		}
 		externalEvent = FALSE;

--- a/StateMachine.cpp
+++ b/StateMachine.cpp
@@ -11,7 +11,7 @@ StateMachine::StateMachine(BYTE maxStates, BYTE initialState) :
 	m_eventGenerated(FALSE),
 	m_pEventData(NULL)
 {
-	ASSERT_TRUE(MAX_STATES < EVENT_IGNORED);
+  SM_ASSERT_TRUE(MAX_STATES < EVENT_IGNORED);
 }
 
 //----------------------------------------------------------------------------
@@ -98,9 +98,9 @@ void StateMachine::StateEngine(const StateMapRow* const pStateMap)
 	while (m_eventGenerated)
 	{
 		// Error check that the new state is valid before proceeding
-		ASSERT_TRUE(m_newState < MAX_STATES);
+                SM_ASSERT_TRUE(m_newState < MAX_STATES);
 
-		// Get the pointer from the state map
+                // Get the pointer from the state map
 		const StateBase* state = pStateMap[m_newState].State;
 
 		// Copy of event data pointer
@@ -116,8 +116,8 @@ void StateMachine::StateEngine(const StateMapRow* const pStateMap)
 		SetCurrentState(m_newState);
 
 		// Execute the state action passing in event data
-		ASSERT_TRUE(state != NULL);
-		state->InvokeStateAction(this, pDataTemp);
+                SM_ASSERT_TRUE(state != NULL);
+                state->InvokeStateAction(this, pDataTemp);
 
 		// If event data was used, then delete it
 #if EXTERNAL_EVENT_NO_HEAP_DATA
@@ -152,9 +152,9 @@ void StateMachine::StateEngine(const StateMapRowEx* const pStateMapEx)
 	while (m_eventGenerated)
 	{
 		// Error check that the new state is valid before proceeding
-		ASSERT_TRUE(m_newState < MAX_STATES);
+                SM_ASSERT_TRUE(m_newState < MAX_STATES);
 
-		// Get the pointers from the state map
+                // Get the pointers from the state map
 		const StateBase* state = pStateMapEx[m_newState].State;
 		const GuardBase* guard = pStateMapEx[m_newState].Guard;
 		const EntryBase* entry = pStateMapEx[m_newState].Entry;
@@ -189,15 +189,15 @@ void StateMachine::StateEngine(const StateMapRowEx* const pStateMapEx)
 					entry->InvokeEntryAction(this, pDataTemp);
 
 				// Ensure exit/entry actions didn't call InternalEvent by accident
-				ASSERT_TRUE(m_eventGenerated == FALSE);
-			}
+                                SM_ASSERT_TRUE(m_eventGenerated == FALSE);
+                        }
 
 			// Switch to the new current state
 			SetCurrentState(m_newState);
 
 			// Execute the state action passing in event data
-			ASSERT_TRUE(state != NULL);
-			state->InvokeStateAction(this, pDataTemp);
+                        SM_ASSERT_TRUE(state != NULL);
+                        state->InvokeStateAction(this, pDataTemp);
 		}
 
 		// If event data was used, then delete it

--- a/StateMachine.h
+++ b/StateMachine.h
@@ -65,9 +65,9 @@ public:
 		// This next internal event is not valid and causes the assert to fail:
 		//    InternalEvent(ST_MY_STATE_FUNCTION, new OtherEventData());
 		const Data* derivedData = dynamic_cast<const Data*>(data);
-		ASSERT_TRUE(derivedData != NULL);
+                SM_ASSERT_TRUE(derivedData != NULL);
 
-		// Call the state function
+                // Call the state function
 		(derivedSM->*Func)(derivedData);
 	}
 };
@@ -96,9 +96,9 @@ public:
 	{
 		SM* derivedSM = static_cast<SM*>(sm);
 		const Data* derivedData = dynamic_cast<const Data*>(data);
-		ASSERT_TRUE(derivedData != NULL);
+                SM_ASSERT_TRUE(derivedData != NULL);
 
-		// Call the guard function
+                // Call the guard function
 		return (derivedSM->*Func)(derivedData);
 	}
 };
@@ -125,9 +125,9 @@ public:
 	{
 		SM* derivedSM = static_cast<SM*>(sm);
 		const Data* derivedData = dynamic_cast<const Data*>(data);
-		ASSERT_TRUE(derivedData != NULL);
+                SM_ASSERT_TRUE(derivedData != NULL);
 
-		// Call the entry function
+                // Call the entry function
 		(derivedSM->*Func)(derivedData);
 	}
 };
@@ -281,11 +281,12 @@ private:
 #define TRANSITION_MAP_ENTRY(entry)\
     entry,
 
-#define END_TRANSITION_MAP(data) \
-    };\
-	ASSERT_TRUE(GetCurrentState() < ST_MAX_STATES); \
-    ExternalEvent(TRANSITIONS[GetCurrentState()], data); \
-	C_ASSERT((sizeof(TRANSITIONS)/sizeof(BYTE)) == ST_MAX_STATES);
+#define END_TRANSITION_MAP(data)                       \
+  }                                                    \
+  ;                                                    \
+  SM_ASSERT_TRUE(GetCurrentState() < ST_MAX_STATES);   \
+  ExternalEvent(TRANSITIONS[GetCurrentState()], data); \
+  C_ASSERT((sizeof(TRANSITIONS) / sizeof(BYTE)) == ST_MAX_STATES);
 
 #define PARENT_TRANSITION(state) \
 	if (GetCurrentState() >= ST_MAX_STATES && \

--- a/StateMachine.h
+++ b/StateMachine.h
@@ -7,18 +7,18 @@
 #include "Fault.h"
 
 // If EXTERNAL_EVENT_NO_HEAP_DATA is defined it changes how a client sends data to the
-// state machine. When undefined, the ExternalEvent() pData argument must be created on the heap. 
-// The state machine will automatically delete the EventData pointer during state execution. 
-// When defined, clients must not heap allocate EventData with operator new. InternalEvent() 
-// used inside the state machine always heap allocates event data. 
+// state machine. When undefined, the ExternalEvent() pData argument must be created on the heap.
+// The state machine will automatically delete the EventData pointer during state execution.
+// When defined, clients must not heap allocate EventData with operator new. InternalEvent()
+// used inside the state machine always heap allocates event data.
 //#define EXTERNAL_EVENT_NO_HEAP_DATA 1
 
 // See http://www.codeproject.com/Articles/1087619/State-Machine-Design-in-Cplusplus
 
-// Uncomment the include below the XALLOCATOR line to use the xallocator instead 
-// of the global heap. Any EventData, or derived class thereof, created with 
-// new/delete will be routed to the xallocator. See xallocator.h for more info. 
-//#include "xallocator.h"
+// Uncomment the include below the XALLOCATOR line to use the xallocator instead
+// of the global heap. Any EventData, or derived class thereof, created with
+// new/delete will be routed to the xallocator. See xallocator.h for more info.
+// #include "xallocator.h"
 
 /// @beief Unique state machine event data must inherit from this class.
 class EventData
@@ -37,27 +37,27 @@ class StateBase
 {
 public:
 	/// Called by the state machine engine to execute a state action. If a guard condition
-	/// exists and it evaluates to false, the state action will not execute. 
-	/// @param[in] sm - A state machine instance. 
-	/// @param[in] data - The event data. 
+	/// exists and it evaluates to false, the state action will not execute.
+	/// @param[in] sm - A state machine instance.
+	/// @param[in] data - The event data.
 	virtual void InvokeStateAction(StateMachine* sm, const EventData* data) const = 0;
 };
 
 /// @brief StateAction takes three template arguments: A state machine class,
-/// a state function event data type (derived from EventData) and a state machine 
-/// member function pointer.  
+/// a state function event data type (derived from EventData) and a state machine
+/// member function pointer.
 template <class SM, class Data, void (SM::*Func)(const Data*)>
 class StateAction : public StateBase
 {
 public:
 	/// @see StateBase::InvokeStateAction
-	virtual void InvokeStateAction(StateMachine* sm, const EventData* data) const 
+	virtual void InvokeStateAction(StateMachine* sm, const EventData* data) const
 	{
 		// Downcast the state machine and event data to the correct derived type
 		SM* derivedSM = static_cast<SM*>(sm);
-		
-		// If this check fails, there is a mismatch between the STATE_DECLARE 
-		// event data type and the data type being sent to the state function. 
+
+		// If this check fails, there is a mismatch between the STATE_DECLARE
+		// event data type and the data type being sent to the state function.
 		// For instance, given the following state defintion:
 		//    STATE_DECLARE(MyStateMachine, MyStateFunction, MyEventData)
 		// The following internal event transition is valid:
@@ -79,22 +79,22 @@ public:
 	/// Called by the state machine engine to execute a guard condition action. If guard
 	/// condition evaluates to TRUE the state action is executed. If FALSE, no state transition
 	/// is performed.
-	/// @param[in] sm - A state machine instance. 
-	/// @param[in] data - The event data. 
+	/// @param[in] sm - A state machine instance.
+	/// @param[in] data - The event data.
 	/// @return Returns TRUE if no guard condition or the guard condition evaluates to TRUE.
 	virtual BOOL InvokeGuardCondition(StateMachine* sm, const EventData* data) const = 0;
 };
 
 /// @brief GuardCondition takes three template arguments: A state machine class,
-/// a state function event data type (derived from EventData) and a state machine 
-/// member function pointer. 
+/// a state function event data type (derived from EventData) and a state machine
+/// member function pointer.
 template <class SM, class Data, BOOL (SM::*Func)(const Data*)>
 class GuardCondition : public GuardBase
 {
 public:
-	virtual BOOL InvokeGuardCondition(StateMachine* sm, const EventData* data) const 
+	virtual BOOL InvokeGuardCondition(StateMachine* sm, const EventData* data) const
 	{
-		SM* derivedSM = static_cast<SM*>(sm);		
+		SM* derivedSM = static_cast<SM*>(sm);
 		const Data* derivedData = dynamic_cast<const Data*>(data);
 		ASSERT_TRUE(derivedData != NULL);
 
@@ -108,15 +108,15 @@ class EntryBase
 {
 public:
 	/// Called by the state machine engine to execute a state entry action. Called when
-	/// entering a state. 
-	/// @param[in] sm - A state machine instance. 
+	/// entering a state.
+	/// @param[in] sm - A state machine instance.
 	/// @param[in] data - The event data.
 	virtual void InvokeEntryAction(StateMachine* sm, const EventData* data) const = 0;
 };
 
 /// @brief EntryAction takes three template arguments: A state machine class,
-/// a state function event data type (derived from EventData) and a state machine 
-/// member function pointer.  
+/// a state function event data type (derived from EventData) and a state machine
+/// member function pointer.
 template <class SM, class Data, void (SM::*Func)(const Data*)>
 class EntryAction : public EntryBase
 {
@@ -137,13 +137,13 @@ class ExitBase
 {
 public:
 	/// Called by the state machine engine to execute a state exit action. Called when
-	/// leaving a state. 
-	/// @param[in] sm - A state machine instance. 
+	/// leaving a state.
+	/// @param[in] sm - A state machine instance.
 	virtual void InvokeExitAction(StateMachine* sm) const = 0;
 };
 
 /// @brief ExitAction takes two template arguments: A state machine class and
-/// a state machine member function pointer.   
+/// a state machine member function pointer.
 template <class SM, void (SM::*Func)(void)>
 class ExitAction : public ExitBase
 {
@@ -157,13 +157,13 @@ public:
 	}
 };
 
-/// @brief A structure to hold a single row within the state map. 
+/// @brief A structure to hold a single row within the state map.
 struct StateMapRow
 {
 	const StateBase* const State;
 };
 
-/// @brief A structure to hold a single row within the extended state map. 
+/// @brief A structure to hold a single row within the extended state map.
 struct StateMapRowEx
 {
 	const StateBase* const State;
@@ -172,8 +172,8 @@ struct StateMapRowEx
 	const ExitBase* const Exit;
 };
 
-/// @brief StateMachine implements a software-based state machine. 
-class StateMachine 
+/// @brief StateMachine implements a software-based state machine.
+class StateMachine
 {
 public:
 	enum { EVENT_IGNORED = 0xFE, CANNOT_HAPPEN };
@@ -189,9 +189,9 @@ public:
 	BYTE GetCurrentState() { return m_currentState; }
 
 	/// Gets the maximum number of state machine states.
-	/// @return The maximum state machine states. 
+	/// @return The maximum state machine states.
 	BYTE GetMaxStates() { return MAX_STATES; }
-	
+
 protected:
 	/// External state machine event.
 	/// @param[in] newState - the state machine state to transition to.
@@ -203,7 +203,7 @@ protected:
 	/// @param[in] newState - the state machine state to transition to.
 	/// @param[in] pData - the event data sent to the state.
 	void InternalEvent(BYTE newState, const EventData* pData = NULL);
-	
+
 private:
 	/// The maximum number of state machine states.
 	const BYTE MAX_STATES;
@@ -211,7 +211,7 @@ private:
 	/// The current state machine state.
 	BYTE m_currentState;
 
-	/// The new state the state machine has yet to transition to. 
+	/// The new state the state machine has yet to transition to.
 	BYTE m_newState;
 
 	/// Set to TRUE when an event is generated.
@@ -222,17 +222,17 @@ private:
 
 	/// Gets the state map as defined in the derived class. The BEGIN_STATE_MAP,
 	/// STATE_MAP_ENTRY and END_STATE_MAP macros are used to assist in creating the
-	/// map. A state machine only needs to return a state map using either GetStateMap()  
-	/// or GetStateMapEx() but not both. 
+	/// map. A state machine only needs to return a state map using either GetStateMap()
+	/// or GetStateMapEx() but not both.
 	/// @return An array of StateMapRow pointers with the array size MAX_STATES or
-	/// NULL if the state machine uses the GetStateMapEx(). 
+	/// NULL if the state machine uses the GetStateMapEx().
 	virtual const StateMapRow* GetStateMap() = 0;
 
 	/// Gets the extended state map as defined in the derived class. The BEGIN_STATE_MAP_EX,
-	/// STATE_MAP_ENTRY_EX, STATE_MAP_ENTRY_ALL_EX, and END_STATE_MAP_EX macros are used to 
-	/// assist in creating the map. A state machine only needs to return a state map using 
-	/// either GetStateMap() or GetStateMapEx() but not both. 
-	/// @return An array of StateMapRowEx pointers with the array size MAX_STATES or 
+	/// STATE_MAP_ENTRY_EX, STATE_MAP_ENTRY_ALL_EX, and END_STATE_MAP_EX macros are used to
+	/// assist in creating the map. A state machine only needs to return a state map using
+	/// either GetStateMap() or GetStateMapEx() but not both.
+	/// @return An array of StateMapRowEx pointers with the array size MAX_STATES or
 	/// NULL if the state machine uses the GetStateMap().
 	virtual const StateMapRowEx* GetStateMapEx() = 0;
 
@@ -240,9 +240,9 @@ private:
 	/// @param[in] newState - the new state.
 	void SetCurrentState(BYTE newState) { m_currentState = newState; }
 
-	/// State machine engine that executes the external event and, optionally, all 
+	/// State machine engine that executes the external event and, optionally, all
 	/// internal events generated during state execution.
-	void StateEngine(void); 	
+	void StateEngine(void);
 	void StateEngine(const StateMapRow* const pStateMap);
 	void StateEngine(const StateMapRowEx* const pStateMapEx);
 };
@@ -250,28 +250,28 @@ private:
 #define STATE_DECLARE(stateMachine, stateName, eventData) \
 	void ST_##stateName(const eventData*); \
 	StateAction<stateMachine, eventData, &stateMachine::ST_##stateName> stateName;
-	
+
 #define STATE_DEFINE(stateMachine, stateName, eventData) \
 	void stateMachine::ST_##stateName(const eventData* data)
-		
+
 #define GUARD_DECLARE(stateMachine, guardName, eventData) \
 	BOOL GD_##guardName(const eventData*); \
 	GuardCondition<stateMachine, eventData, &stateMachine::GD_##guardName> guardName;
-	
+
 #define GUARD_DEFINE(stateMachine, guardName, eventData) \
 	BOOL stateMachine::GD_##guardName(const eventData* data)
 
 #define ENTRY_DECLARE(stateMachine, entryName, eventData) \
 	void EN_##entryName(const eventData*); \
 	EntryAction<stateMachine, eventData, &stateMachine::EN_##entryName> entryName;
-	
+
 #define ENTRY_DEFINE(stateMachine, entryName, eventData) \
 	void stateMachine::EN_##entryName(const eventData* data)
 
 #define EXIT_DECLARE(stateMachine, exitName) \
 	void EX_##exitName(void); \
 	ExitAction<stateMachine, &stateMachine::EX_##exitName> exitName;
-	
+
 #define EXIT_DEFINE(stateMachine, exitName) \
 	void stateMachine::EX_##exitName(void)
 
@@ -285,19 +285,19 @@ private:
     };\
 	ASSERT_TRUE(GetCurrentState() < ST_MAX_STATES); \
     ExternalEvent(TRANSITIONS[GetCurrentState()], data); \
-	C_ASSERT((sizeof(TRANSITIONS)/sizeof(BYTE)) == ST_MAX_STATES); 
+	C_ASSERT((sizeof(TRANSITIONS)/sizeof(BYTE)) == ST_MAX_STATES);
 
 #define PARENT_TRANSITION(state) \
 	if (GetCurrentState() >= ST_MAX_STATES && \
 		GetCurrentState() < GetMaxStates()) { \
 		ExternalEvent(state); \
 		return; }
-	
+
 #define BEGIN_STATE_MAP \
 	private:\
 	virtual const StateMapRowEx* GetStateMapEx() { return NULL; }\
 	virtual const StateMapRow* GetStateMap() {\
-		static const StateMapRow STATE_MAP[] = { 
+		static const StateMapRow STATE_MAP[] = {
 
 #define STATE_MAP_ENTRY(stateName)\
 	stateName,
@@ -311,7 +311,7 @@ private:
 	private:\
 	virtual const StateMapRow* GetStateMap() { return NULL; }\
 	virtual const StateMapRowEx* GetStateMapEx() {\
-		static const StateMapRowEx STATE_MAP[] = { 
+		static const StateMapRowEx STATE_MAP[] = {
 
 #define STATE_MAP_ENTRY_EX(stateName)\
 	{ stateName, 0, 0, 0 },

--- a/xallocator.cpp
+++ b/xallocator.cpp
@@ -95,7 +95,7 @@ static void lock_init()
 {
 #if WIN32
 	BOOL success = InitializeCriticalSectionAndSpinCount(&_criticalSection, 0x00000400);
-	ASSERT_TRUE(success != 0);
+        SM_ASSERT_TRUE(success != 0);
 #endif
 	_xallocInitialized = TRUE;
 }
@@ -300,7 +300,7 @@ extern "C" Allocator* xallocator_get_allocator(size_t size)
 	Allocator* allocator = find_allocator(blockSize);
 
 #ifdef STATIC_POOLS
-	ASSERT_TRUE(allocator != NULL);
+        SM_ASSERT_TRUE(allocator != NULL);
 #else
 	// If there is not an allocator already created to handle this block size
 	if (allocator == NULL)


### PR DESCRIPTION
InternalEvent could always use the heap, even when called from ExternalEvent
actions with NoEventData.
This update has InternalEvent also respect the no heap rule

We also need ASSERT_TRUE to be isolated to this library